### PR TITLE
Fix application path

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,7 +4,7 @@
     "application_name": "Name of the project",
     "application_slug": "{{ cookiecutter.application_name.lower().replace(' ', '_') }}",
     "application_user": "hack",
-    "application_root": "/{{ cookiecutter.application_user }}/{{ cookiecutter.application_slug }}/",
+    "application_root": "/{{ cookiecutter.application_user }}/{{ cookiecutter.application_slug }}",
     "staging_server_domain": "staging.example.com",
     "production_server_domain": "example.com",
     "add_your_pulic_key": "y",

--- a/{{ cookiecutter.ansible_project_slug }}/roles/application/templates/application_upstart.j2
+++ b/{{ cookiecutter.ansible_project_slug }}/roles/application/templates/application_upstart.j2
@@ -19,10 +19,10 @@ script
     WORKERS={{ gunicorn_workers }}
     USER={{ application_user }}
     GROUP={{ application_user }}
-    LOGFILE={{ application_root }}shared/log/gunicorn.log
+    LOGFILE={{ application_root }}/shared/log/gunicorn.log
     
-    cd {{ application_root }}current/
-    exec {{ application_root }}shared/virtualenv/bin/gunicorn \
+    cd {{ application_root }}/current/
+    exec {{ application_root }}/shared/virtualenv/bin/gunicorn \
             -w $WORKERS -t $TIMEOUT \
             --user=$USER --group=$GROUP \
             --name=$NAME \

--- a/{{ cookiecutter.ansible_project_slug }}/roles/celery/templates/celery_upstart.j2
+++ b/{{ cookiecutter.ansible_project_slug }}/roles/celery/templates/celery_upstart.j2
@@ -13,7 +13,7 @@ respawn limit 3 30
 script
     eval $(cat /etc/environment | sed 's/^/export /')
 
-    cd {{ application_root }}current
-    exec {{ application_root }}shared/virtualenv/bin/celery -A {{ application_name }} worker -B -E --loglevel=info
+    cd {{ application_root }}/current
+    exec {{ application_root }}/shared/virtualenv/bin/celery -A {{ application_name }} worker -B -E --loglevel=info
 end script
 {% endraw %}


### PR DESCRIPTION
Nearly all paths in the ansible config files that are prepended with `{{ application_root }}` start with `/`.
I removed the trailing slash to avoid paths like `application_root//releases` and added a `/` where it was missing.